### PR TITLE
some libraries do not exist on linux, allow to start also from other folders

### DIFF
--- a/qna_webapp/haystack_qna.py
+++ b/qna_webapp/haystack_qna.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, HTTPException
 
 
 import logging
+import os
 
 from haystack import Finder
 from haystack.database import app
@@ -50,7 +51,7 @@ db.create_all()
 
 # Let's first get some documents that we want to query
 # Here: 517 Wikipedia articles for Game of Thrones
-doc_dir = "../data"
+doc_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "data")
 # Note: requires changing the function in io.py and adding encoding='utf-8' in our case
 write_documents_to_db(document_dir=doc_dir, clean_func=clean_wiki_text) # , only_empty_db=True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,13 +61,11 @@ protobuf==3.11.2
 psycopg2-binary==2.8.4
 pydantic==1.3
 Pygments==2.5.2
-pypiwin32==223
 pyrsistent==0.15.7
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-multipart==0.0.5
 pytz==2019.3
-pywin32==227
 PyYAML==5.3
 querystring-parser==1.2.4
 regex==2020.1.8
@@ -88,8 +86,9 @@ SQLAlchemy==1.3.12
 sqlparse==0.3.0
 starlette==0.12.9
 tabulate==0.8.6
-torch==1.4.0+cpu
-torchvision==0.5.0+cpu
+torch[cpu]==1.4.0
+# I think this torchvision version is wrong, but is it really needed?
+torchvision[cpu]==0.2.2
 tqdm==4.41.1
 traitlets==4.3.3
 transformers==2.1.1
@@ -100,3 +99,7 @@ websocket-client==0.57.0
 websockets==8.1
 Werkzeug==0.16.0
 zipp==1.0.0
+
+# Only relevant for Windows
+pypiwin32==223
+pywin32==227


### PR DESCRIPTION
On Linux there are no libraries `pypiwin32` and `pywin32`, so I had to remove them from the requirements.txt. Since Windows users will need them, I just moved them to a separate location so that we can remove them easier on Linux PCs.

I did not run `haystack_qna.py` from the folder `qna_webapp`, but from the project root folder. Thus, the relative path `../data` did not work for me and I changed the path `../data` to a dynamic calculation based on the script's location (`qna_webapp/haystack_qna.py` -> `..` -> `data`).